### PR TITLE
:technologist: now handlers are agnostic

### DIFF
--- a/components/node-service-api-request-handlers/package.json
+++ b/components/node-service-api-request-handlers/package.json
@@ -24,11 +24,9 @@
         "@types/koa": "^2.13.4",
         "@types/node": "^17.0.23",
         "jest": "^27.5.1",
-        "koa": "^2.13.4",
         "zod": "^3.14.4"
     },
     "peerDependencies": {
-        "koa": "*",
         "zod": "*"
     },
     "dependencies": {

--- a/components/node-service-api-request-handlers/src/cart/handlers.ts
+++ b/components/node-service-api-request-handlers/src/cart/handlers.ts
@@ -1,18 +1,13 @@
-import { Cart, CartHydraterArguments, CartItem, CartRequest } from './types';
+import { Cart, CartHydraterArguments, CartItem, CartPayload } from './types';
 import { CrystallizeHydraterBySkus, ProductPriceVariant } from '@crystallize/js-api-client';
 import type { ProductVariant, Product } from '@crystallize/js-api-client';
-import Koa from 'koa';
 
-export const handleCartRequest = async (
-    request: CartRequest,
-    context: Koa.Context,
-    args?: CartHydraterArguments
-): Promise<Cart> => {
-    const skus = request.items.map((item) => item.sku);
+export const handleCartRequestPayload = async (payload: CartPayload, args: CartHydraterArguments): Promise<Cart> => {
+    const skus = payload.items.map((item) => item.sku);
 
     const hydraterParameters = {
         skus,
-        locale: request.locale,
+        locale: payload.locale,
         ...args
     };
 
@@ -24,7 +19,7 @@ export const handleCartRequest = async (
         (item: string, index: number) => {
             return {
                 ...(hydraterParameters.perVariant !== undefined ? hydraterParameters.perVariant(item, index) : {}),
-                ...(request.withImages === undefined || request.withImages === false
+                ...(payload.withImages === undefined || payload.withImages === false
                     ? {}
                     : {
                           images: {
@@ -51,7 +46,7 @@ export const handleCartRequest = async (
         taxAmount: 0
     };
 
-    const items: CartItem[] = request.items.map((item) => {
+    const items: CartItem[] = payload.items.map((item) => {
         let selectedVariant: ProductVariant | undefined;
 
         const product: Product | undefined = products.find((product: Product) => {

--- a/components/node-service-api-request-handlers/src/cart/types.ts
+++ b/components/node-service-api-request-handlers/src/cart/types.ts
@@ -1,19 +1,19 @@
 import { z } from 'zod';
 import type { Image, Product, ProductVariant, ProductPriceVariant } from '@crystallize/js-api-client';
 
-const cartItemRequest = z.object({
+const cartItemPayload = z.object({
     sku: z.string(),
     quantity: z.number()
 });
 
-export const cartRequest = z.object({
+export const cartPayload = z.object({
     locale: z.string(),
     withImages: z.boolean().optional(),
-    items: z.array(cartItemRequest)
+    items: z.array(cartItemPayload)
 });
 
-export type CartRequest = z.infer<typeof cartRequest>;
-export type CartItemRequest = z.infer<typeof cartItemRequest>;
+export type CartPayload = z.infer<typeof cartPayload>;
+export type CartItemPayload = z.infer<typeof cartItemPayload>;
 
 export interface Cart {
     cart: {

--- a/components/node-service-api-request-handlers/src/magicklink/handlers.ts
+++ b/components/node-service-api-request-handlers/src/magicklink/handlers.ts
@@ -1,72 +1,57 @@
-import Koa from 'koa';
 import jwt from 'jsonwebtoken';
 import {
     MagickLinkConfirmArguments,
     MagickLinkRegisterArguments,
     MagickLinkUserInfos,
-    MagickLinkUserInfosRequest
+    MagickLinkUserInfosPayload
 } from './types';
 
-export async function handleMagickLinkRegisterRequest(
-    request: MagickLinkUserInfosRequest,
-    context: Koa.Context,
+export async function handleMagickLinkRegisterPayload(
+    payload: MagickLinkUserInfosPayload,
     args: MagickLinkRegisterArguments
 ): Promise<MagickLinkUserInfos> {
     // we use a symetric key here to make it simple, but in production you should use a public/private key pair
     // which will allow you to verify the token client side too, (even if not really required it is a good idea)
-    const magickToken = jwt.sign(request, args.jwtSecret, {
+    const magickToken = jwt.sign(payload, args.jwtSecret, {
         expiresIn: '30m',
-        audience: request.email,
+        audience: payload.email,
         subject: 'magicklink',
-        issuer: context.request.host
+        issuer: args.host
     });
-    const link = `http${context.secure ? 's' : ''}://${context.request.host}${args.confirmLinkPath.replace(
-        ':token',
-        magickToken
-    )}`;
-    args.mailer(args.subject, request.email, args.from, args.buildHtml(request, link));
-    return request;
+    const link = args.confirmLinkUrl.replace(':token', magickToken);
+    args.mailer(args.subject, payload.email, args.from, args.buildHtml(payload, link));
+    return payload;
 }
 
-export async function handleMagickLinkConfirmationRequest(
-    request: any,
-    context: Koa.Context,
+export async function handleMagickLinkConfirmationRequestPayload(
+    payload: any,
     args: MagickLinkConfirmArguments
-): Promise<MagickLinkUserInfos> {
-    const magickToken: string = (context.params.token || '') as string;
-    try {
-        const magickTokenDecoded: MagickLinkUserInfos = jwt.verify(magickToken, args.jwtSecret) as MagickLinkUserInfos;
-        // now we create 2 tokens, one for the frontend to indicate that we are logged in and one for the service api in the Cookie
-        // the token for the frontend is NOT a prood of login
-        const isSupposedToBeLoggedInOnServiceApiToken = jwt.sign(
-            {
-                email: magickTokenDecoded.email,
-                firstname: magickTokenDecoded.firstname,
-                lastname: magickTokenDecoded.lastname
-            },
-            args.jwtSecret,
-            {
-                expiresIn: '1d',
-                audience: magickTokenDecoded.email,
-                subject: 'isSupposedToBeLoggedInOnServiceApi',
-                issuer: context.request.host
-            }
-        );
-
-        const isLoggedInOnServiceApiToken = jwt.sign({}, args.jwtSecret, {
+): Promise<string> {
+    const magickToken: string = (args.token || '') as string;
+    const magickTokenDecoded: MagickLinkUserInfos = jwt.verify(magickToken, args.jwtSecret) as MagickLinkUserInfos;
+    // now we create 2 tokens, one for the frontend to indicate that we are logged in and one for the service api in the Cookie
+    // the token for the frontend is NOT a prood of login
+    const isSupposedToBeLoggedInOnServiceApiToken = jwt.sign(
+        {
+            email: magickTokenDecoded.email,
+            firstname: magickTokenDecoded.firstname,
+            lastname: magickTokenDecoded.lastname
+        },
+        args.jwtSecret,
+        {
             expiresIn: '1d',
             audience: magickTokenDecoded.email,
-            subject: 'isLoggedInOnServiceApiToken',
-            issuer: context.request.host
-        });
-        context.cookies.set('jwt', isLoggedInOnServiceApiToken, { httpOnly: false, secure: context.secure });
-        context.response.redirect(args.backLinkPath.replace(':token', isSupposedToBeLoggedInOnServiceApiToken));
+            subject: 'isSupposedToBeLoggedInOnServiceApi',
+            issuer: args.host
+        }
+    );
 
-        console.log(magickTokenDecoded);
-        return magickTokenDecoded;
-    } catch (exception) {
-        console.log(exception);
-        context.body = { exception };
-    }
-    return {} as MagickLinkUserInfos;
+    const isLoggedInOnServiceApiToken = jwt.sign({}, args.jwtSecret, {
+        expiresIn: '1d',
+        audience: magickTokenDecoded.email,
+        subject: 'isLoggedInOnServiceApiToken',
+        issuer: args.host
+    });
+    args.setCookie('jwt', isLoggedInOnServiceApiToken);
+    return args.backLinkPath.replace(':token', isSupposedToBeLoggedInOnServiceApiToken);
 }

--- a/components/node-service-api-request-handlers/src/magicklink/types.ts
+++ b/components/node-service-api-request-handlers/src/magicklink/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const magickLinkUserInfosRequest = z
+export const magickLinkUserInfosPayload = z
     .object({
         email: z.string(),
         firstname: z.string(),
@@ -8,13 +8,14 @@ export const magickLinkUserInfosRequest = z
     })
     .strict();
 
-export type MagickLinkUserInfosRequest = z.infer<typeof magickLinkUserInfosRequest>;
-export type MagickLinkUserInfos = MagickLinkUserInfosRequest;
+export type MagickLinkUserInfosPayload = z.infer<typeof magickLinkUserInfosPayload>;
+export type MagickLinkUserInfos = MagickLinkUserInfosPayload;
 
 export type MagickLinkRegisterArguments = {
+    host: string;
     mailer: (subject: string, to: string[] | string, from: string, html: string) => void;
     jwtSecret: string;
-    confirmLinkPath: string;
+    confirmLinkUrl: string;
     subject: string;
     from: string;
     buildHtml: (request: MagickLinkUserInfos, link: string) => string;
@@ -23,4 +24,7 @@ export type MagickLinkRegisterArguments = {
 export type MagickLinkConfirmArguments = {
     jwtSecret: string;
     backLinkPath: string;
+    token: string;
+    host: string;
+    setCookie: (name: string, value: string) => void;
 };

--- a/components/node-service-api-request-handlers/src/order/handlers.ts
+++ b/components/node-service-api-request-handlers/src/order/handlers.ts
@@ -1,4 +1,3 @@
-import Koa from 'koa';
 import {
     CrystallizeOrderFetcherById,
     CrystallizeOrderFetcherByCustomerIdentifier,
@@ -6,14 +5,14 @@ import {
 } from '@crystallize/js-api-client';
 import { OrderArguments, OrdersArguments } from './types';
 
-export async function handleOrderRequest(request: any, context: Koa.Context, args: OrderArguments): Promise<Order> {
+export async function handleOrderRequestPayload(payload: any, args: OrderArguments): Promise<Order> {
     const order = await CrystallizeOrderFetcherById(
-        context.params.id,
+        args.orderId,
         args?.onCustomer,
         args?.onOrderItem,
         args?.extraQuery
     );
-    if (order.customer?.identifier !== context.user) {
+    if (order.customer?.identifier !== args.user) {
         throw {
             status: 403,
             message: 'Unauthorized. That is not your order.'
@@ -22,10 +21,10 @@ export async function handleOrderRequest(request: any, context: Koa.Context, arg
     return order;
 }
 
-export async function handleOrdersRequest(request: any, context: Koa.Context, args: OrdersArguments): Promise<Order[]> {
+export async function handleOrdersRequestPayload(payload: any, args: OrdersArguments): Promise<Order[]> {
     // @todo: handle pagination
     const pagination = await CrystallizeOrderFetcherByCustomerIdentifier(
-        context.user,
+        args.user,
         args?.extraQueryArgs,
         args?.onCustomer,
         args?.onOrderItem,

--- a/components/node-service-api-request-handlers/src/order/types.ts
+++ b/components/node-service-api-request-handlers/src/order/types.ts
@@ -1,10 +1,13 @@
 export type OrderArguments = {
+    orderId: string;
+    user: string;
     onCustomer?: any;
     onOrderItem?: any;
     extraQuery?: any;
 };
 
 export type OrdersArguments = {
+    user: string;
     extraQueryArgs?: any;
     onCustomer?: any;
     onOrderItem?: any;

--- a/components/node-service-api-router/src/types/routing.ts
+++ b/components/node-service-api-router/src/types/routing.ts
@@ -1,23 +1,22 @@
 import Koa from 'koa';
-
 export const httpMethods = ['get', 'post', 'put', 'patch', 'delete'] as const;
 export type HttpMethod = typeof httpMethods[number];
 
-export interface ValidatingRoute<S, T> {
+export interface ValidatingRoute<T> {
     schema?: any;
-    handler: (request: any, context: Koa.Context, args?: any) => Promise<T>;
-    args?: any;
+    handler: (payload: any, args: any) => Promise<T>;
+    args: (context: any) => any;
     authenticated?: boolean;
 }
 
 export interface StandardRoute {
-    handler: (ctx: Koa.Context) => Promise<void>;
+    handler: (context: Koa.Context) => Promise<void>;
     authenticated?: boolean;
 }
 
-export interface ValidatingRequestRouting<S extends object = {}, T extends object = {}> {
+export interface ValidatingRequestRouting<T extends object = {}> {
     [path: string]: {
-        [method in HttpMethod]?: ValidatingRoute<S, T>;
+        [method in HttpMethod]?: ValidatingRoute<T>;
     };
 }
 


### PR DESCRIPTION
it was a bit tricky.

Now the handler are agnostic.

```javascript
const handleCartRequestPayload = async (payload: CartPayload, args: CartHydraterArguments): Promise<Cart> => {
```

On the handler level that's clean dead simple, a payload (not a request anymore) and arguments that are typed (like before to manage injection)

Then the complex part was on the Routing because we need the "framework context", so the final solution is still simple.
Args is a closure that receive the framework context and must return the argument for the handler (instead of the argument directly before)
https://github.com/CrystallizeAPI/libraries/pull/8/files#diff-f5127ee36b6418fc659d24d26234df319a919e8265cdbb16067339efec5debf7R35

Typescript is kind enough to let us type in the `index.ts` (of the app). So when using Koa we can still type and when using something else we will be able to as well.

=> no more dependencies on the handlers!

If we are using the api router, we can do:

```javascript
const bodyConvertedRoutes: ValidatingRequestRouting = {
    '/cart': {
        post: {
            schema: cartPayload,
            handler: handleCartRequestPayload,
            args: (context: Koa.Context): CartHydraterArguments => {
                return {
                    perVariant: () => {
                        return {
                            id: true
                        }
                    }
                }
            }
        }
    }
},
    "/confirm/email/magicklink/:token": {
        get: {
            schema: null,
            handler: handleMagickLinkConfirmationRequestPayload,
            args: (context: Koa.Context): MagickLinkConfirmArguments => {
                return {
                    token: context.params.token,
                    host: context.request.host,
                    jwtSecret: `${process.env.JWT_SECRET}`,
                    backLinkPath: 'https://frontend.app.crystal/checkout?token=:token',
                    setCookie: (name: string, value: string) => {
                        context.cookies.set(name, value, { httpOnly: false, secure: context.secure });
                    }
                }
            }
        },
    },
```

If we are not using the api router, we can do what we want, we just use the handler directly !
