### PR TITLE
feat: Add id properties to all nodes by default for navigationFetcher

### DIFF
--- a/components/js-api-client/package.json
+++ b/components/js-api-client/package.json
@@ -10,6 +10,7 @@
         "watch": "yarn tsc -W",
         "build": "yarn tsc",
         "test": "jest",
+        "test:watch": "jest --watch",
         "bump": "yarn tsc && yarn version --no-git-tag-version --new-version"
     },
     "repository": {

--- a/components/js-api-client/src/core/navigation.ts
+++ b/components/js-api-client/src/core/navigation.ts
@@ -8,6 +8,7 @@ export enum NavigationType {
 
 function nestedQuery(depth: number, start: number = 1, extraQuery?: (currentLevel: number) => any): any {
     const props = {
+        id: true,
         name: true,
         path: true,
         ...(extraQuery !== undefined ? extraQuery(start - 1) : {}),

--- a/components/js-api-client/tests/navigationFolders.test.js
+++ b/components/js-api-client/tests/navigationFolders.test.js
@@ -1,88 +1,111 @@
 const { createNavigationFetcher, createClient } = require('../dist/index.js');
+const { walkTree } = require('./util')
 
 test('Test Nav fetching Node: Shop', async () => {
-    const CrystallizeClient = createClient({
-        tenantIdentifier: 'furniture',
-    });
+  const CrystallizeClient = createClient({
+    tenantIdentifier: 'furniture',
+  });
 
-    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-    const response = await fetch('/shop', 'en', 3);
+  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+  const response = await fetch('/shop', 'en', 3);
 
-    expect(response.tree.path).toBe('/shop');
-    expect(response.tree.children[0].path).toBe('/shop/decoration');
-    expect(response.tree.children[0].children[0].path).toBe('/shop/decoration/shelves-in-wood-hey');
+  expect(response.tree.path).toBe('/shop');
+  expect(response.tree.children[0].path).toBe('/shop/decoration');
+  expect(response.tree.children[0].children[0].path).toBe('/shop/decoration/shelves-in-wood-hey');
 
-    expect(response.tree.children[1].path).toBe('/shop/bathroom-fitting');
-    expect(response.tree.children[1].children[2].path).toBe('/shop/bathroom-fitting/mounted-bathroom-vanity-in-gray');
+  expect(response.tree.children[1].path).toBe('/shop/bathroom-fitting');
+  expect(response.tree.children[1].children[2].path).toBe('/shop/bathroom-fitting/mounted-bathroom-vanity-in-gray');
+
+  // Verify all tree nodes have id properties
+  walkTree([response.tree], node => {
+    expect(node).toHaveProperty('id')
+  })
 });
 
 test('Test Nav fetching Node: /', async () => {
-    const CrystallizeClient = createClient({
-        tenantIdentifier: 'furniture',
-    });
+  const CrystallizeClient = createClient({
+    tenantIdentifier: 'furniture',
+  });
 
-    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-    const response = await fetch('/', 'en', 3);
-    expect(response.tree.path).toBe('/');
-    expect(response.tree.children[0].path).toBe('/shop');
+  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+  const response = await fetch('/', 'en', 3);
+  expect(response.tree.path).toBe('/');
+  expect(response.tree.children[0].path).toBe('/shop');
+
+
+  // Verify all tree nodes have id properties
+  walkTree([response.tree], node => {
+    expect(node).toHaveProperty('id')
+  })
 });
 
 test('Test Nav fetching Node: / + extra data', async () => {
-    const CrystallizeClient = createClient({
-        tenantIdentifier: 'furniture',
-    });
+  const CrystallizeClient = createClient({
+    tenantIdentifier: 'furniture',
+  });
 
-    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-    const response = await fetch('/', 'en', 2, {
-        tenant: {
-            __args: {
-                language: 'en',
-            },
-            name: true,
-        },
-    });
-    expect(response.tree.path).toBe('/');
-    expect(response.tree.children[0].path).toBe('/shop');
-    expect(response.tenant.name).toBe('Furniture');
+  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+  const response = await fetch('/', 'en', 2, {
+    tenant: {
+      __args: {
+        language: 'en',
+      },
+      name: true,
+    },
+  });
+  expect(response.tree.path).toBe('/');
+  expect(response.tree.children[0].path).toBe('/shop');
+  expect(response.tenant.name).toBe('Furniture');
+
+  // Verify all tree nodes have id properties
+  walkTree([response.tree], node => {
+    expect(node).toHaveProperty('id')
+  })
 });
 
 test('Test Nav fetching Node: / + extra data + specific level', async () => {
-    const CrystallizeClient = createClient({
-        tenantIdentifier: 'furniture',
-    });
+  const CrystallizeClient = createClient({
+    tenantIdentifier: 'furniture',
+  });
 
-    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-    const response = await fetch(
-        '/',
-        'en',
-        3,
-        {
-            tenant: {
-                __args: {
-                    language: 'en',
-                },
-                name: true,
+  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+  const response = await fetch(
+    '/',
+    'en',
+    3,
+    {
+      tenant: {
+        __args: {
+          language: 'en',
+        },
+        name: true,
+      },
+    },
+    (level) => {
+      switch (level) {
+        case 0:
+          return {
+            shape: {
+              identifier: true,
             },
-        },
-        (level) => {
-            switch (level) {
-                case 0:
-                    return {
-                        shape: {
-                            identifier: true,
-                        },
-                    };
-                case 1:
-                    return {
-                        createdAt: true,
-                    };
-                default:
-                    return {};
-            }
-        },
-    );
-    expect(response.tree.path).toBe('/');
-    expect(response.tree.children[0].path).toBe('/shop');
-    expect(response.tenant.name).toBe('Furniture');
-    expect(response.tree.shape.identifier).toBe('__catalogue-tree-root');
+          };
+        case 1:
+          return {
+            createdAt: true,
+          };
+        default:
+          return {};
+      }
+    },
+  );
+  expect(response.tree.path).toBe('/');
+  expect(response.tree.children[0].path).toBe('/shop');
+  expect(response.tenant.name).toBe('Furniture');
+  expect(response.tree.shape.identifier).toBe('__catalogue-tree-root');
+
+
+  // Verify all tree nodes have id properties
+  walkTree([response.tree], node => {
+    expect(node).toHaveProperty('id')
+  })
 });

--- a/components/js-api-client/tests/navigationFolders.test.js
+++ b/components/js-api-client/tests/navigationFolders.test.js
@@ -1,111 +1,109 @@
 const { createNavigationFetcher, createClient } = require('../dist/index.js');
-const { walkTree } = require('./util')
+const { walkTree } = require('./util');
 
 test('Test Nav fetching Node: Shop', async () => {
-  const CrystallizeClient = createClient({
-    tenantIdentifier: 'furniture',
-  });
+    const CrystallizeClient = createClient({
+        tenantIdentifier: 'furniture',
+    });
 
-  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-  const response = await fetch('/shop', 'en', 3);
+    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+    const response = await fetch('/shop', 'en', 3);
 
-  expect(response.tree.path).toBe('/shop');
-  expect(response.tree.children[0].path).toBe('/shop/decoration');
-  expect(response.tree.children[0].children[0].path).toBe('/shop/decoration/shelves-in-wood-hey');
+    expect(response.tree.path).toBe('/shop');
+    expect(response.tree.children[0].path).toBe('/shop/decoration');
+    expect(response.tree.children[0].children[0].path).toBe('/shop/decoration/shelves-in-wood-hey');
 
-  expect(response.tree.children[1].path).toBe('/shop/bathroom-fitting');
-  expect(response.tree.children[1].children[2].path).toBe('/shop/bathroom-fitting/mounted-bathroom-vanity-in-gray');
+    expect(response.tree.children[1].path).toBe('/shop/bathroom-fitting');
+    expect(response.tree.children[1].children[2].path).toBe('/shop/bathroom-fitting/mounted-bathroom-vanity-in-gray');
 
-  // Verify all tree nodes have id properties
-  walkTree([response.tree], node => {
-    expect(node).toHaveProperty('id')
-  })
+    // Verify all tree nodes have id properties
+    walkTree([response.tree], (node) => {
+        expect(node).toHaveProperty('id');
+    });
 });
 
 test('Test Nav fetching Node: /', async () => {
-  const CrystallizeClient = createClient({
-    tenantIdentifier: 'furniture',
-  });
+    const CrystallizeClient = createClient({
+        tenantIdentifier: 'furniture',
+    });
 
-  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-  const response = await fetch('/', 'en', 3);
-  expect(response.tree.path).toBe('/');
-  expect(response.tree.children[0].path).toBe('/shop');
+    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+    const response = await fetch('/', 'en', 3);
+    expect(response.tree.path).toBe('/');
+    expect(response.tree.children[0].path).toBe('/shop');
 
-
-  // Verify all tree nodes have id properties
-  walkTree([response.tree], node => {
-    expect(node).toHaveProperty('id')
-  })
+    // Verify all tree nodes have id properties
+    walkTree([response.tree], (node) => {
+        expect(node).toHaveProperty('id');
+    });
 });
 
 test('Test Nav fetching Node: / + extra data', async () => {
-  const CrystallizeClient = createClient({
-    tenantIdentifier: 'furniture',
-  });
+    const CrystallizeClient = createClient({
+        tenantIdentifier: 'furniture',
+    });
 
-  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-  const response = await fetch('/', 'en', 2, {
-    tenant: {
-      __args: {
-        language: 'en',
-      },
-      name: true,
-    },
-  });
-  expect(response.tree.path).toBe('/');
-  expect(response.tree.children[0].path).toBe('/shop');
-  expect(response.tenant.name).toBe('Furniture');
+    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+    const response = await fetch('/', 'en', 2, {
+        tenant: {
+            __args: {
+                language: 'en',
+            },
+            name: true,
+        },
+    });
+    expect(response.tree.path).toBe('/');
+    expect(response.tree.children[0].path).toBe('/shop');
+    expect(response.tenant.name).toBe('Furniture');
 
-  // Verify all tree nodes have id properties
-  walkTree([response.tree], node => {
-    expect(node).toHaveProperty('id')
-  })
+    // Verify all tree nodes have id properties
+    walkTree([response.tree], (node) => {
+        expect(node).toHaveProperty('id');
+    });
 });
 
 test('Test Nav fetching Node: / + extra data + specific level', async () => {
-  const CrystallizeClient = createClient({
-    tenantIdentifier: 'furniture',
-  });
+    const CrystallizeClient = createClient({
+        tenantIdentifier: 'furniture',
+    });
 
-  const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
-  const response = await fetch(
-    '/',
-    'en',
-    3,
-    {
-      tenant: {
-        __args: {
-          language: 'en',
-        },
-        name: true,
-      },
-    },
-    (level) => {
-      switch (level) {
-        case 0:
-          return {
-            shape: {
-              identifier: true,
+    const fetch = createNavigationFetcher(CrystallizeClient).byFolders;
+    const response = await fetch(
+        '/',
+        'en',
+        3,
+        {
+            tenant: {
+                __args: {
+                    language: 'en',
+                },
+                name: true,
             },
-          };
-        case 1:
-          return {
-            createdAt: true,
-          };
-        default:
-          return {};
-      }
-    },
-  );
-  expect(response.tree.path).toBe('/');
-  expect(response.tree.children[0].path).toBe('/shop');
-  expect(response.tenant.name).toBe('Furniture');
-  expect(response.tree.shape.identifier).toBe('__catalogue-tree-root');
+        },
+        (level) => {
+            switch (level) {
+                case 0:
+                    return {
+                        shape: {
+                            identifier: true,
+                        },
+                    };
+                case 1:
+                    return {
+                        createdAt: true,
+                    };
+                default:
+                    return {};
+            }
+        },
+    );
+    expect(response.tree.path).toBe('/');
+    expect(response.tree.children[0].path).toBe('/shop');
+    expect(response.tenant.name).toBe('Furniture');
+    expect(response.tree.shape.identifier).toBe('__catalogue-tree-root');
 
-
-  // Verify all tree nodes have id properties
-  walkTree([response.tree], node => {
-    expect(node).toHaveProperty('id')
-  })
+    // Verify all tree nodes have id properties
+    walkTree([response.tree], (node) => {
+        expect(node).toHaveProperty('id');
+    });
 });

--- a/components/js-api-client/tests/navigationTopics.test.js
+++ b/components/js-api-client/tests/navigationTopics.test.js
@@ -1,81 +1,98 @@
 const { createNavigationFetcher, createClient } = require('../dist/index.js');
+const { walkTree } = require('./util')
 
 test('Test Nav fetching Topic: /', async () => {
-    const CrystallizeClient = createClient({
-        tenantIdentifier: 'furniture',
-    });
+  const CrystallizeClient = createClient({
+    tenantIdentifier: 'furniture',
+  });
 
-    const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
-    const response = await fetch('/', 'en', 3);
+  const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
+  const response = await fetch('/', 'en', 3);
 
-    // fetch topics returns a list of topics with no parents
-    expect(response.tree[0].name).toBe('Specials');
-    expect(response.tree[0].path).toBe('/specials');
-    expect(response.tree[1].children[0].path).toBe('/room/livingroom');
+  // fetch topics returns a list of topics with no parents
+  expect(response.tree[0].name).toBe('Specials');
+  expect(response.tree[0].path).toBe('/specials');
+  expect(response.tree[1].children[0].path).toBe('/room/livingroom');
+
+  // Verify all tree nodes have id properties
+  walkTree(response.tree, node => {
+    expect(node).toHaveProperty('id')
+  })
+
 });
 
 test('Test Nav fetching Topic: /specials', async () => {
-    const CrystallizeClient = createClient({
-        tenantIdentifier: 'furniture',
-    });
+  const CrystallizeClient = createClient({
+    tenantIdentifier: 'furniture',
+  });
 
-    const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
-    const response = await fetch('/specials', 'en', 3);
+  const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
+  const response = await fetch('/specials', 'en', 3);
 
-    expect(response.tree.name).toBe('Specials');
-    expect(response.tree.path).toBe('/specials');
-    expect(response.tree.children[1].path).toBe('/specials/new-arrival');
+  expect(response.tree.name).toBe('Specials');
+  expect(response.tree.path).toBe('/specials');
+  expect(response.tree.children[1].path).toBe('/specials/new-arrival');
+
+  // Verify all tree nodes have id properties
+  walkTree([response.tree], node => {
+    expect(node).toHaveProperty('id')
+  })
 });
 
 test('Test Nav fetching Topic: /specials + extra data + specific level', async () => {
-    const CrystallizeClient = createClient({
-        tenantIdentifier: 'furniture',
-    });
+  const CrystallizeClient = createClient({
+    tenantIdentifier: 'furniture',
+  });
 
-    const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
-    const response = await fetch(
-        '/specials',
-        'en',
-        3,
-        {
-            tenant: {
-                __args: {
-                    language: 'en',
-                },
-                name: true,
+  const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
+  const response = await fetch(
+    '/specials',
+    'en',
+    3,
+    {
+      tenant: {
+        __args: {
+          language: 'en',
+        },
+        name: true,
+      },
+    },
+    (level) => {
+      switch (level) {
+        case 0:
+          return {
+            parentId: true,
+          };
+        case 1:
+          return {
+            parent: {
+              path: true,
             },
-        },
-        (level) => {
-            switch (level) {
-                case 0:
-                    return {
-                        parentId: true,
-                    };
-                case 1:
-                    return {
-                        parent: {
-                            path: true,
-                        },
-                        items: {
-                            edges: {
-                                node: {
-                                    path: true,
-                                },
-                            },
-                        },
-                    };
-                case 2:
-                    return {
-                        createdAt: true,
-                    };
-                default:
-                    return {};
-            }
-        },
-    );
-    expect(response.tree.path).toBe('/specials');
-    expect(response.tree.children[0].name).toBe('Organic');
-    expect(response.tree.children[0].parent.path).toBe('/specials');
+            items: {
+              edges: {
+                node: {
+                  path: true,
+                },
+              },
+            },
+          };
+        case 2:
+          return {
+            createdAt: true,
+          };
+        default:
+          return {};
+      }
+    },
+  );
+  expect(response.tree.path).toBe('/specials');
+  expect(response.tree.children[0].name).toBe('Organic');
+  expect(response.tree.children[0].parent.path).toBe('/specials');
 
-    expect(response.tree.children[0].items.edges[0].node.path).toBe('/shop/plants/monstera-deliciosa');
+  expect(response.tree.children[0].items.edges[0].node.path).toBe('/shop/plants/monstera-deliciosa');
+
+  // Verify all tree nodes have id properties
+  walkTree([response.tree], node => {
+    expect(node).toHaveProperty('id')
+  })
 });

--- a/components/js-api-client/tests/navigationTopics.test.js
+++ b/components/js-api-client/tests/navigationTopics.test.js
@@ -1,98 +1,97 @@
 const { createNavigationFetcher, createClient } = require('../dist/index.js');
-const { walkTree } = require('./util')
+const { walkTree } = require('./util');
 
 test('Test Nav fetching Topic: /', async () => {
-  const CrystallizeClient = createClient({
-    tenantIdentifier: 'furniture',
-  });
+    const CrystallizeClient = createClient({
+        tenantIdentifier: 'furniture',
+    });
 
-  const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
-  const response = await fetch('/', 'en', 3);
+    const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
+    const response = await fetch('/', 'en', 3);
 
-  // fetch topics returns a list of topics with no parents
-  expect(response.tree[0].name).toBe('Specials');
-  expect(response.tree[0].path).toBe('/specials');
-  expect(response.tree[1].children[0].path).toBe('/room/livingroom');
+    // fetch topics returns a list of topics with no parents
+    expect(response.tree[0].name).toBe('Specials');
+    expect(response.tree[0].path).toBe('/specials');
+    expect(response.tree[1].children[0].path).toBe('/room/livingroom');
 
-  // Verify all tree nodes have id properties
-  walkTree(response.tree, node => {
-    expect(node).toHaveProperty('id')
-  })
-
+    // Verify all tree nodes have id properties
+    walkTree(response.tree, (node) => {
+        expect(node).toHaveProperty('id');
+    });
 });
 
 test('Test Nav fetching Topic: /specials', async () => {
-  const CrystallizeClient = createClient({
-    tenantIdentifier: 'furniture',
-  });
+    const CrystallizeClient = createClient({
+        tenantIdentifier: 'furniture',
+    });
 
-  const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
-  const response = await fetch('/specials', 'en', 3);
+    const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
+    const response = await fetch('/specials', 'en', 3);
 
-  expect(response.tree.name).toBe('Specials');
-  expect(response.tree.path).toBe('/specials');
-  expect(response.tree.children[1].path).toBe('/specials/new-arrival');
+    expect(response.tree.name).toBe('Specials');
+    expect(response.tree.path).toBe('/specials');
+    expect(response.tree.children[1].path).toBe('/specials/new-arrival');
 
-  // Verify all tree nodes have id properties
-  walkTree([response.tree], node => {
-    expect(node).toHaveProperty('id')
-  })
+    // Verify all tree nodes have id properties
+    walkTree([response.tree], (node) => {
+        expect(node).toHaveProperty('id');
+    });
 });
 
 test('Test Nav fetching Topic: /specials + extra data + specific level', async () => {
-  const CrystallizeClient = createClient({
-    tenantIdentifier: 'furniture',
-  });
+    const CrystallizeClient = createClient({
+        tenantIdentifier: 'furniture',
+    });
 
-  const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
-  const response = await fetch(
-    '/specials',
-    'en',
-    3,
-    {
-      tenant: {
-        __args: {
-          language: 'en',
-        },
-        name: true,
-      },
-    },
-    (level) => {
-      switch (level) {
-        case 0:
-          return {
-            parentId: true,
-          };
-        case 1:
-          return {
-            parent: {
-              path: true,
-            },
-            items: {
-              edges: {
-                node: {
-                  path: true,
+    const fetch = createNavigationFetcher(CrystallizeClient).byTopics;
+    const response = await fetch(
+        '/specials',
+        'en',
+        3,
+        {
+            tenant: {
+                __args: {
+                    language: 'en',
                 },
-              },
+                name: true,
             },
-          };
-        case 2:
-          return {
-            createdAt: true,
-          };
-        default:
-          return {};
-      }
-    },
-  );
-  expect(response.tree.path).toBe('/specials');
-  expect(response.tree.children[0].name).toBe('Organic');
-  expect(response.tree.children[0].parent.path).toBe('/specials');
+        },
+        (level) => {
+            switch (level) {
+                case 0:
+                    return {
+                        parentId: true,
+                    };
+                case 1:
+                    return {
+                        parent: {
+                            path: true,
+                        },
+                        items: {
+                            edges: {
+                                node: {
+                                    path: true,
+                                },
+                            },
+                        },
+                    };
+                case 2:
+                    return {
+                        createdAt: true,
+                    };
+                default:
+                    return {};
+            }
+        },
+    );
+    expect(response.tree.path).toBe('/specials');
+    expect(response.tree.children[0].name).toBe('Organic');
+    expect(response.tree.children[0].parent.path).toBe('/specials');
 
-  expect(response.tree.children[0].items.edges[0].node.path).toBe('/shop/plants/monstera-deliciosa');
+    expect(response.tree.children[0].items.edges[0].node.path).toBe('/shop/plants/monstera-deliciosa');
 
-  // Verify all tree nodes have id properties
-  walkTree([response.tree], node => {
-    expect(node).toHaveProperty('id')
-  })
+    // Verify all tree nodes have id properties
+    walkTree([response.tree], (node) => {
+        expect(node).toHaveProperty('id');
+    });
 });

--- a/components/js-api-client/tests/util.js
+++ b/components/js-api-client/tests/util.js
@@ -1,10 +1,10 @@
-function walkTree (tree, cb) {
-  tree.forEach(node => {
-    cb(node)
-    if (node?.children?.length) {
-      walkTree(node.children, cb)
-    }
-  })
+function walkTree(tree, cb) {
+    tree.forEach((node) => {
+        cb(node);
+        if (node?.children?.length) {
+            walkTree(node.children, cb);
+        }
+    });
 }
 
-module.exports = { walkTree }
+module.exports = { walkTree };

--- a/components/js-api-client/tests/util.js
+++ b/components/js-api-client/tests/util.js
@@ -1,0 +1,10 @@
+function walkTree (tree, cb) {
+  tree.forEach(node => {
+    cb(node)
+    if (node?.children?.length) {
+      walkTree(node.children, cb)
+    }
+  })
+}
+
+module.exports = { walkTree }


### PR DESCRIPTION
| Q             | A            |
| ------------- | ------------ |
| Branch?       | feat/navigation-tree-with-ids |
| Bug fix?      | no       |
| New feature?  | yes       |
| BC breaks?    | no       |
| Fixed tickets | #...         |

Add id properties to all nodes by default for `navigationFetcher`
