### PR TITLE
IDEA: Auto-fetch tenant id to make using tenantIdentifier "seamless"

### DIFF
--- a/components/js-api-client/src/core/client.ts
+++ b/components/js-api-client/src/core/client.ts
@@ -1,21 +1,21 @@
 import fetch from 'node-fetch';
 
-export interface ClientConfiguration {
+export type ClientConfiguration = {
     tenantIdentifier: string;
     accessTokenId?: string;
     accessTokenSecret?: string;
-}
+};
 
 export type VariablesType = { [key: string]: string | number | string[] | number[] };
 export type ApiCaller<T> = (query: string, variables?: VariablesType) => Promise<T>;
 
-export interface ClientInterface {
+export type ClientInterface = {
     catalogueApi: ApiCaller<any>;
     searchApi: ApiCaller<any>;
     orderApi: ApiCaller<any>;
     subscriptionApi: ApiCaller<any>;
     pimApi: ApiCaller<any>;
-}
+};
 
 async function post<T>(
     path: string,
@@ -55,18 +55,59 @@ async function post<T>(
     }
 }
 
+function createApiCaller(
+    uri: string,
+    configuration: ClientConfiguration,
+    getTenantId: () => Promise<string>,
+): ApiCaller<any> {
+    /**
+     * Call a crystallize. Will automatically handle access tokens
+     * @param query The GraphQL query
+     * @param variables Variables to inject into query.
+     */
+    return async function callApi<T>(query: string, variables?: VariablesType): Promise<T> {
+        const tenantId = await getTenantId();
+        return post<T>(uri, configuration, query, { tenantId, ...variables });
+    };
+}
+
+const apiHost = (path: string[], prefix: 'api' | 'pim' = 'api') =>
+    `https://${prefix}.crystallize.com/${path.join('/')}`;
+
+/**
+ * Create one api client for each api endpoint Crystallize offers (catalogue, search, order, subscription, pim).
+ *
+ * @param configuration
+ * @returns ClientInterface
+ */
 export function createClient(configuration: ClientConfiguration): ClientInterface {
-    function createApiCaller(uri: string): ApiCaller<any> {
-        return function callApi<T>(query: string, variables?: VariablesType): Promise<T> {
-            return post<T>(uri, configuration, query, variables);
-        };
-    }
+    const identifier = configuration.tenantIdentifier;
+
+    const getTenantId = async (): Promise<string> => {
+        if (process.env?.TENANT_ID) {
+            return process.env.TENANT_ID;
+        }
+
+        const result = (await post(
+            apiHost(['graphql'], 'pim'),
+            configuration,
+            `query FETCH_TENANT_CONFIG ($identifier: String!) {
+                tenant {
+                    get(identifier: $identifier) {
+                        id 
+                    }
+                }
+            }`,
+            { identifier },
+        )) as { tenant: { get: { id: string } } };
+        return result.tenant.get.id;
+    };
 
     return {
-        catalogueApi: createApiCaller(`https://api.crystallize.com/${configuration.tenantIdentifier}/catalogue`),
-        searchApi: createApiCaller(`https://api.crystallize.com/${configuration.tenantIdentifier}/search`),
-        orderApi: createApiCaller(`https://api.crystallize.com/${configuration.tenantIdentifier}/orders`),
-        subscriptionApi: createApiCaller(`https://api.crystallize.com/${configuration.tenantIdentifier}/subscriptions`),
-        pimApi: createApiCaller(`https://pim.crystallize.com/graphql`),
+        catalogueApi: createApiCaller(apiHost([identifier, 'catalogue']), configuration, getTenantId),
+        searchApi: createApiCaller(apiHost([identifier, 'search']), configuration, getTenantId),
+        orderApi: createApiCaller(apiHost([identifier, 'orders']), configuration, getTenantId),
+        subscriptionApi: createApiCaller(apiHost([identifier, 'subscriptions']), configuration, getTenantId),
+        pimApi: createApiCaller(apiHost(['graphql'], 'pim'), configuration, getTenantId),
     };
 }

--- a/components/js-api-client/src/index.ts
+++ b/components/js-api-client/src/index.ts
@@ -19,9 +19,10 @@ import { createCatalogueFetcher } from './core/catalogue';
 import { createSearcher } from './core/search';
 
 export const CrystallizeClient = createClient({
-    tenantIdentifier: typeof process === 'object' ? process?.env.CRYSTALLIZE_TENANT_IDENTIFIER || '' : '',
-    accessTokenId: typeof process === 'object' ? process?.env.CRYSTALLIZE_ACCESS_TOKEN_ID || '' : '',
-    accessTokenSecret: typeof process === 'object' ? process?.env.CRYSTALLIZE_ACCESS_TOKEN_SECRET || '' : '',
+    tenantId: process?.env?.CRYSTALLIZE_TENANT_ID ?? '',
+    tenantIdentifier: process?.env?.CRYSTALLIZE_TENANT_IDENTIFIER ?? '',
+    accessTokenId: process?.env?.CRYSTALLIZE_ACCESS_TOKEN_ID ?? '',
+    accessTokenSecret: process?.env?.CRYSTALLIZE_ACCESS_TOKEN_SECRET ?? '',
 });
 
 const navigationFetcher = createNavigationFetcher(CrystallizeClient);

--- a/components/js-storefrontaware-utils/src/adapters/superfast.server.ts
+++ b/components/js-storefrontaware-utils/src/adapters/superfast.server.ts
@@ -9,6 +9,8 @@ type TStorage = {
 
 type MemoryCache = Record<string, { expiresAt: number; value: any }>;
 
+const getExpiry = (ttl: number): number => Math.floor(Date.now() / 1000) + ttl;
+
 /**
  * Create Superfast adapter
  *
@@ -21,8 +23,6 @@ export const createSuperFastAdapter = (
     ttl: number,
 ): TStoreFrontAdapter => {
     const memoryCache: MemoryCache = {};
-
-    const getExpiry = (): number => Math.floor(Date.now() / 1000) + ttl;
     const { decrypt, decryptMap } = cypher(process.env.ENCRYPTED_PARAMS_SECRET as string);
 
     /**
@@ -58,7 +58,7 @@ export const createSuperFastAdapter = (
 
         if (config !== undefined) {
             memoryCache[domainkey] = {
-                expiresAt: getExpiry(),
+                expiresAt: getExpiry(ttl),
                 value: config,
             };
 


### PR DESCRIPTION
| Q             | A            |
| ------------- | ------------ |
| Branch?       | main / x.y.z |
| Bug fix?      |  no       |
| New feature?  | yes       |
| BC breaks?    | yes/no       |
| Fixed tickets | #...         |

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

Experimental/idea to enable discussion around dealing with tenant id vs identifier.
This will allow you to write queries as if tenantId existed, perhaps making it possible to write code that focuses on just providing tenant identifier.

```graphql
pimApi(`query ($tenantId: ID!) { tenant { get(id: $tenantId) } }`, { noVarsNeededHere: null })
```