### PR TITLE
Introducing Subscriptions Contract Manager

### DIFF
--- a/components/js-api-client/src/core/catalogue.ts
+++ b/components/js-api-client/src/core/catalogue.ts
@@ -6,6 +6,7 @@ import {
     CatalogueFetcherGrapqhqlOnFolder,
     CatalogueFetcherGrapqhqlOnItem,
     CatalogueFetcherGrapqhqlOnProduct,
+    CatalogueFetcherGrapqhqlOnSubscriptionPlan,
     componentType,
     ComponentType,
 } from '../types/catalogue';
@@ -22,6 +23,7 @@ export const catalogueFetcherGraphqlBuilder = {
     onDocument,
     onFolder,
     onComponent,
+    onSubscriptionPlan,
 };
 
 function onItem(onItem?: any, c?: CatalogueFetcherGrapqhqlOnItem): any {
@@ -140,6 +142,47 @@ function onComponent(id: string, type: ComponentType, onComponent?: any, c?: Cat
                     __typeName: validType,
                     ...onComponent,
                 },
+            },
+        },
+    };
+}
+
+function onSubscriptionPlan(c?: CatalogueFetcherGrapqhqlOnSubscriptionPlan): any {
+    const period = (name: string) => {
+        return {
+            ...(c?.onPeriod ? c.onPeriod(name) : {}),
+            priceVariants: {
+                identifier: true,
+                name: true,
+                price: true,
+                currency: true,
+            },
+            meteredVariables: {
+                id: true,
+                name: true,
+                identifier: true,
+                tierType: true,
+                tiers: {
+                    threshold: true,
+                    priceVariants: {
+                        identifier: true,
+                        name: true,
+                        price: true,
+                        currency: true,
+                    },
+                },
+            },
+        };
+    };
+    return {
+        subscriptionPlans: {
+            identifier: true,
+            name: true,
+            periods: {
+                id: true,
+                name: true,
+                initial: period('initial'),
+                recurring: period('recurring'),
             },
         },
     };

--- a/components/js-api-client/src/core/subscription.ts
+++ b/components/js-api-client/src/core/subscription.ts
@@ -1,0 +1,231 @@
+import { EnumType, jsonToGraphQLQuery } from 'json-to-graphql-query';
+import {
+    ProductPriceVariant,
+    ProductVariant,
+    ProductVariantSubscriptionPlan,
+    ProductVariantSubscriptionPlanPeriod,
+    ProductVariantSubscriptionMeteredVariable,
+    ProductVariantSubscriptionPlanTier,
+    ProductVariantSubscriptionPlanPricing,
+} from '../types/product';
+import {
+    createSubscriptionContractInputRequest,
+    CreateSubscriptionContractInputRequest,
+    SubscriptionContractMeteredVariableReferenceInputRequest,
+    SubscriptionContractMeteredVariableTierInputRequest,
+    SubscriptionContractPhaseInput,
+    updateSubscriptionContractInputRequest,
+    UpdateSubscriptionContractInputRequest,
+} from '../types/subscription';
+import { catalogueFetcherGraphqlBuilder, createCatalogueFetcher } from './catalogue';
+import { ClientInterface } from './client';
+
+export function createSubscriptionContractManager(apiClient: ClientInterface) {
+    const create = async (
+        intentSubsctiptionContract: CreateSubscriptionContractInputRequest,
+        extraResultQuery?: any,
+    ): Promise<any> => {
+        const intent = createSubscriptionContractInputRequest.parse(intentSubsctiptionContract);
+        const api = apiClient.pimApi;
+
+        const mutation = {
+            mutation: {
+                subscriptionContract: {
+                    create: {
+                        __args: {
+                            input: {
+                                ...intent,
+                            },
+                        },
+                        id: true,
+                        createdAt: true,
+                        ...(extraResultQuery !== undefined ? extraResultQuery : {}),
+                    },
+                },
+            },
+        };
+        const confirmation = await api(jsonToGraphQLQuery(mutation));
+        return confirmation.subscriptionContract.create;
+    };
+
+    const update = async (
+        id: string,
+        intentSubsctiptionContract: UpdateSubscriptionContractInputRequest,
+        extraResultQuery?: any,
+    ): Promise<any> => {
+        const intent = updateSubscriptionContractInputRequest.parse(intentSubsctiptionContract);
+        const api = apiClient.pimApi;
+
+        const mutation = {
+            mutation: {
+                subscriptionContract: {
+                    update: {
+                        __args: {
+                            id,
+                            input: {
+                                ...intent,
+                            },
+                        },
+                        id: true,
+                        createdAt: true,
+                        ...(extraResultQuery !== undefined ? extraResultQuery : {}),
+                    },
+                },
+            },
+        };
+        const confirmation = await api(jsonToGraphQLQuery(mutation));
+        return confirmation.subscriptionContract.update;
+    };
+
+    /**
+     * This function assumes that the variant contains the subscriptions plans
+     */
+    const createSubscriptionContractTemplateBasedOnVariant = async (
+        variant: ProductVariant,
+        planIdentifier: string,
+        periodId: string,
+        priceVariantIdentifier: string,
+    ) => {
+        const matchingPlan: ProductVariantSubscriptionPlan | undefined = variant?.subscriptionPlans?.find(
+            (plan: ProductVariantSubscriptionPlan) => plan.identifier === planIdentifier,
+        );
+        const matchingPeriod: ProductVariantSubscriptionPlanPeriod | undefined = matchingPlan?.periods?.find(
+            (period: ProductVariantSubscriptionPlanPeriod) => period.id === periodId,
+        );
+        if (!matchingPlan || !matchingPeriod) {
+            throw new Error(
+                `Impossible to find the Subscription Plans for SKU ${variant.sku}, plan: ${planIdentifier}, period: ${periodId}`,
+            );
+        }
+
+        const getPriceVariant = (
+            priceVariants: ProductPriceVariant[],
+            identifier: string,
+        ): ProductPriceVariant | undefined => {
+            return priceVariants.find((priceVariant: ProductPriceVariant) => priceVariant.identifier === identifier);
+        };
+
+        const transformPeriod = (period: ProductVariantSubscriptionPlanPricing): SubscriptionContractPhaseInput => {
+            return {
+                currency: getPriceVariant(period.priceVariants || [], priceVariantIdentifier)?.currency || 'USD',
+                price: getPriceVariant(period.priceVariants || [], priceVariantIdentifier)?.price || 0.0,
+                meteredVariables: (period.meteredVariables || []).map(
+                    (
+                        meteredVariable: ProductVariantSubscriptionMeteredVariable,
+                    ): SubscriptionContractMeteredVariableReferenceInputRequest => {
+                        return {
+                            id: meteredVariable.id,
+                            tierType: new EnumType(meteredVariable.tierType),
+                            tiers: meteredVariable.tiers.map(
+                                (
+                                    tier: ProductVariantSubscriptionPlanTier,
+                                ): SubscriptionContractMeteredVariableTierInputRequest => {
+                                    return {
+                                        threshold: tier.threshold,
+                                        currency:
+                                            getPriceVariant(tier.priceVariants || [], priceVariantIdentifier)
+                                                ?.currency || 'USD',
+                                        price:
+                                            getPriceVariant(tier.priceVariants || [], priceVariantIdentifier)?.price ||
+                                            0.0,
+                                    };
+                                },
+                            ),
+                        };
+                    },
+                ),
+            };
+        };
+        const contract: Omit<
+            CreateSubscriptionContractInputRequest,
+            'customerIdentifier' | 'payment' | 'addresses' | 'tenantId' | 'status'
+        > = {
+            item: {
+                sku: variant.sku,
+                name: variant.name || '',
+            },
+            subscriptionPlan: {
+                identifier: matchingPlan.identifier,
+                periodId: matchingPeriod.id,
+            },
+            initial: !matchingPeriod.initial ? undefined : transformPeriod(matchingPeriod.initial),
+            recurring: !matchingPeriod.recurring ? undefined : transformPeriod(matchingPeriod.recurring),
+        };
+
+        return contract;
+    };
+
+    /**
+     * This function fetch it all
+     */
+    const createSubscriptionContractTemplateBasedOnVariantIdentity = async (
+        path: string,
+        productVariantIdentifier: { sku?: string; id?: string },
+        planIdentifier: string,
+        periodId: string,
+        priceVariantIdentifier: string,
+        language: string = 'en',
+    ) => {
+        if (!productVariantIdentifier.sku && !productVariantIdentifier.id) {
+            throw new Error(
+                `Impossible to find the Subscription Plans for Path ${path} with and empty Variant Identity`,
+            );
+        }
+
+        // let's ask the catalog for the data we need to create the subscription contract template
+        const fetcher = createCatalogueFetcher(apiClient);
+        const builder = catalogueFetcherGraphqlBuilder;
+        const data: any = await fetcher({
+            catalogue: {
+                __args: {
+                    path,
+                    language,
+                },
+                __on: [
+                    builder.onProduct(
+                        {},
+                        {
+                            onVariant: {
+                                id: true,
+                                name: true,
+                                sku: true,
+                                ...builder.onSubscriptionPlan(),
+                            },
+                        },
+                    ),
+                ],
+            },
+        });
+
+        const matchingVariant: ProductVariant | undefined = data.catalogue?.variants?.find(
+            (variant: ProductVariant) => {
+                if (productVariantIdentifier.sku && variant.sku === productVariantIdentifier.sku) {
+                    return true;
+                }
+                if (productVariantIdentifier.id && variant.id === productVariantIdentifier.id) {
+                    return true;
+                }
+                return false;
+            },
+        );
+
+        if (!matchingVariant) {
+            throw new Error(
+                `Impossible to find the Subscription Plans for Path ${path} and Variant: (sku: ${productVariantIdentifier.sku} id: ${productVariantIdentifier.id}), plan: ${planIdentifier}, period: ${periodId} in lang: ${language}`,
+            );
+        }
+
+        return createSubscriptionContractTemplateBasedOnVariant(
+            matchingVariant,
+            planIdentifier,
+            periodId,
+            priceVariantIdentifier,
+        );
+    };
+    return {
+        create,
+        update,
+        createSubscriptionContractTemplateBasedOnVariantIdentity,
+        createSubscriptionContractTemplateBasedOnVariant,
+    };
+}

--- a/components/js-api-client/src/index.ts
+++ b/components/js-api-client/src/index.ts
@@ -4,11 +4,13 @@ export * from './core/hydrate';
 export * from './core/catalogue';
 export * from './core/order';
 export * from './core/search';
+export * from './core/subscription';
 export * from './types/product';
 export * from './types/order';
 export * from './types/payment';
 export * from './types/components';
 export * from './types/search';
+export * from './types/subscription';
 
 import { createClient } from './core/client';
 import { createNavigationFetcher } from './core/navigation';
@@ -17,6 +19,7 @@ import { createProductHydrater } from './core/hydrate';
 import { createOrderPusher, createOrderPaymentUpdater, createOrderFetcher } from './core/order';
 import { createCatalogueFetcher } from './core/catalogue';
 import { createSearcher } from './core/search';
+import { createSubscriptionContractManager } from './core/subscription';
 
 export const CrystallizeClient = createClient({
     tenantId: globalThis?.process?.env?.CRYSTALLIZE_TENANT_ID ?? '',
@@ -42,3 +45,5 @@ export const CrystallizeSearcher = createSearcher(CrystallizeClient);
 const orderFetcher = createOrderFetcher(CrystallizeClient);
 export const CrystallizeOrderFetcherById = orderFetcher.byId;
 export const CrystallizeOrderFetcherByCustomerIdentifier = orderFetcher.byCustomerIdentifier;
+
+export const CrystallizeSubscriptionContractManager = createSubscriptionContractManager(CrystallizeClient);

--- a/components/js-api-client/src/types/catalogue.ts
+++ b/components/js-api-client/src/types/catalogue.ts
@@ -12,6 +12,10 @@ export type CatalogueFetcherGrapqhqlOnProduct = {
 
 export type CatalogueFetcherGrapqhqlOnDocument = {};
 
+export type CatalogueFetcherGrapqhqlOnSubscriptionPlan = {
+    onPeriod: (name: string) => any;
+};
+
 export type CatalogueFetcherGrapqhqlOnFolder = {
     onChildren?: any;
 };

--- a/components/js-api-client/src/types/order.ts
+++ b/components/js-api-client/src/types/order.ts
@@ -15,26 +15,26 @@ import {
 } from './payment';
 import { SubscriptionPeriodUnit, VatInfo } from './product';
 
-export const orderItemMeteredVariableInput = z
+export const orderItemMeteredVariableInputRequest = z
     .object({
         id: z.string(),
         usage: z.number(),
         price: z.number(),
     })
     .strict();
-export type OrderItemMeteredVariableInput = z.infer<typeof orderItemMeteredVariableInput>;
+export type OrderItemMeteredVariableInputRequest = z.infer<typeof orderItemMeteredVariableInputRequest>;
 
-export const orderItemSubscriptionInput = z
+export const orderItemSubscriptionInputRequest = z
     .object({
         name: z.string().optional(),
         period: z.number(),
         unit: z.enum(['minute', 'hour', 'day', 'week', 'month', 'year']).transform((val) => new EnumType(val)),
         start: z.date().optional(),
         end: z.date().optional(),
-        meteredVariables: z.array(orderItemMeteredVariableInput).optional(),
+        meteredVariables: z.array(orderItemMeteredVariableInputRequest).optional(),
     })
     .strict();
-export type OrderItemSubscriptionInput = z.infer<typeof orderItemSubscriptionInput>;
+export type OrderItemSubscriptionInputRequest = z.infer<typeof orderItemSubscriptionInputRequest>;
 
 export const priceInputRequest = z
     .object({
@@ -70,7 +70,7 @@ export const orderItemInputRequest = z
         productVairantId: z.string().optional(),
         imageUrl: z.string().optional(),
         quantity: z.number(),
-        subscription: orderItemSubscriptionInput.optional(),
+        subscription: orderItemSubscriptionInputRequest.optional(),
         subscriptionContractId: z.string().optional(),
         price: priceInputRequest.optional(),
         subTotal: priceInputRequest.optional(),

--- a/components/js-api-client/src/types/product.ts
+++ b/components/js-api-client/src/types/product.ts
@@ -91,7 +91,7 @@ export interface ProductVariantSubscriptionMeteredVariable {
 }
 
 export interface ProductVariantSubscriptionPlanTier {
-    treshold: number;
+    threshold: number;
     price?: number; //shortcut to ProductPriceVariant[n].price
     priceVariants?: ProductPriceVariant[];
 }

--- a/components/js-api-client/src/types/subscription.ts
+++ b/components/js-api-client/src/types/subscription.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { EnumType } from 'json-to-graphql-query';
+import { addressInputRequest, paymentInputRequest } from './order';
+
+export const subscriptionContractMetadataInputRequest = z
+    .object({
+        key: z.string(),
+        value: z.string(),
+    })
+    .strict();
+export type SubscriptionContractMetadataInputRequest = z.infer<typeof subscriptionContractMetadataInputRequest>;
+
+// Create Contract
+export const subscriptionContractMeteredVariableTierInputRequest = z
+    .object({
+        currency: z.string(),
+        price: z.number(),
+        threshold: z.number(),
+    })
+    .strict();
+export type SubscriptionContractMeteredVariableTierInputRequest = z.infer<
+    typeof subscriptionContractMeteredVariableTierInputRequest
+>;
+
+export const subscriptionContractMeteredVariableReferenceInputRequest = z
+    .object({
+        id: z.string(),
+        tierType: z.enum(['graduated', 'volume']).transform((val) => new EnumType(val)),
+        tiers: z.array(subscriptionContractMeteredVariableTierInputRequest),
+    })
+    .strict();
+export type SubscriptionContractMeteredVariableReferenceInputRequest = z.infer<
+    typeof subscriptionContractMeteredVariableReferenceInputRequest
+>;
+
+export const subscriptionContractPhaseInputRequest = z
+    .object({
+        currency: z.string(),
+        price: z.number(),
+        meteredVariables: z.array(subscriptionContractMeteredVariableReferenceInputRequest),
+    })
+    .strict();
+export type SubscriptionContractPhaseInput = z.infer<typeof subscriptionContractPhaseInputRequest>;
+
+export const createSubscriptionContractInputRequest = z
+    .object({
+        customerIdentifier: z.string(),
+        tenantId: z.string(),
+        addresses: z.array(addressInputRequest).optional(),
+        payment: paymentInputRequest.optional(),
+        subscriptionPlan: z
+            .object({
+                identifier: z.string(),
+                periodId: z.string(),
+            })
+            .optional(),
+        status: z.object({
+            activeUntil: z.date(),
+            currency: z.string(),
+            price: z.number(),
+            renewAt: z.date(),
+        }),
+        item: z.object({
+            sku: z.string(),
+            name: z.string(),
+            imageUrl: z.string().optional(),
+            meta: z.array(subscriptionContractMetadataInputRequest).optional(),
+        }),
+        initial: subscriptionContractPhaseInputRequest.optional(),
+        recurring: subscriptionContractPhaseInputRequest.optional(),
+    })
+    .strict();
+export type CreateSubscriptionContractInputRequest = z.infer<typeof createSubscriptionContractInputRequest>;
+
+// Update Contract
+export const updateSubscriptionContractInputRequest = z
+    .object({
+        addresses: z.array(addressInputRequest).optional(),
+        payment: paymentInputRequest.optional(),
+        status: z
+            .object({
+                activeUntil: z.date().optional(),
+                currency: z.string().optional(),
+                price: z.number().optional(),
+                renewAt: z.date().optional(),
+            })
+            .optional(),
+        item: z
+            .object({
+                sku: z.string().optional(),
+                name: z.string().optional(),
+                imageUrl: z.string().optional(),
+                meta: z.array(subscriptionContractMetadataInputRequest).optional(),
+            })
+            .optional(),
+        initial: subscriptionContractPhaseInputRequest.optional(),
+        recurring: subscriptionContractPhaseInputRequest.optional(),
+    })
+    .strict();
+export type UpdateSubscriptionContractInputRequest = z.infer<typeof updateSubscriptionContractInputRequest>;
+
+export type SubscriptionContractInnerDefinition = Omit<
+    CreateSubscriptionContractInputRequest,
+    'customerIdentifier' | 'payment' | 'addresses' | 'tenantId' | 'status'
+>;

--- a/components/js-api-client/tests/fetch.subcontracttemaplate.test.js
+++ b/components/js-api-client/tests/fetch.subcontracttemaplate.test.js
@@ -1,0 +1,17 @@
+const { CrystallizeSubscriptionContractManager } = require('../dist/index.js');
+test('catalogAPI: Test', async () => {
+    try {
+        const template =
+            await CrystallizeSubscriptionContractManager.createSubscriptionContractTemplateBasedOnVariantIdentity(
+                '/standard-crystal-customer',
+                { id: '62eaf0a5f050cc86e5ded7b1' },
+                'crystal-customer',
+                '62eaf0535978d060e4604c83',
+                'default',
+                'en',
+            );
+        console.log(template);
+    } catch (exception) {
+        // nothing to do here, this is a test manual
+    }
+});

--- a/components/js-api-client/tests/push.subcontract.test.js
+++ b/components/js-api-client/tests/push.subcontract.test.js
@@ -1,0 +1,137 @@
+const { CrystallizeSubscriptionContractManager } = require('../dist/index.js');
+
+const period = {
+    currency: 'eur',
+    price: 5010,
+    meteredVariables: [
+        {
+            id: '62eaf0535978d060e4604c84',
+            tierType: 'volume',
+            tiers: [
+                { currency: 'eur', price: 0, threshold: 0 },
+                { currency: 'eur', price: 0.6, threshold: 1001 },
+            ],
+        },
+        {
+            id: '62eaf0535978d060e4604c85',
+            tierType: 'volume',
+            tiers: [
+                { currency: 'eur', price: 0, threshold: 0 },
+                { currency: 'eur', price: 0.02, threshold: 1000001 },
+            ],
+        },
+        {
+            id: '62eaf0535978d060e4604c86',
+            tierType: 'volume',
+            tiers: [
+                { currency: 'eur', price: 0, threshold: 0 },
+                { currency: 'eur', price: 0.2, threshold: 1001 },
+            ],
+        },
+        {
+            id: '62eaf0535978d060e4604c87',
+            tierType: 'volume',
+            tiers: [
+                { currency: 'eur', price: 0, threshold: 0 },
+                { currency: 'eur', price: 0.000008, threshold: 1000001 },
+            ],
+        },
+        {
+            id: '62eaf0535978d060e4604c88',
+            tierType: 'volume',
+            tiers: [{ currency: 'eur', price: 250, threshold: 0 }],
+        },
+    ],
+};
+
+const contract = {
+    customerIdentifier: 'sebastien@crystallize.com',
+    tenantId: '62eaee71f050cc86e5ded7ad',
+    addresses: [
+        {
+            email: 'sebastien@crystallize.com',
+            firstName: 'Sebastien',
+            lastName: 'Morel',
+            streetNumber: '845',
+            street: 'Market Street',
+            street2: 'Suite 450',
+            city: 'San Francisco',
+            postalCode: '94122',
+            state: 'California',
+            country: 'United States of America',
+            type: 'billing',
+        },
+    ],
+    status: {
+        activeUntil: new Date(),
+        currency: 'eur',
+        price: 999.666,
+        renewAt: new Date(),
+    },
+    subscriptionPlan: {
+        identifier: 'crystal-customer',
+        periodId: '62eaf0535978d060e4604c83',
+    },
+    item: {
+        name: 'Standard Crystal Customer, Default SKU',
+        sku: 'standard-crystal-customer-1659564197202',
+    },
+    payment: {
+        provider: 'custom',
+        custom: {
+            properties: [
+                {
+                    property: 'CreditCardToken',
+                    value: 'X255380637944327017',
+                },
+            ],
+        },
+    },
+};
+
+test('pimAPi: Test Validation', async () => {
+    // it has to fail with 404 because we don't have any credentials
+    try {
+        const caller = CrystallizeSubscriptionContractManager.create;
+        await caller({
+            ...contract,
+            initial2: {
+                ...period,
+            },
+        });
+    } catch (exception) {
+        expect(exception.errors[0].code).toBe('unrecognized_keys');
+    }
+});
+
+test('pimAPi Push a new Contract', async () => {
+    // it has to fail with 404 because we don't have any credentials
+    try {
+        const caller = CrystallizeSubscriptionContractManager.create;
+        await caller({
+            ...contract,
+            initial: {
+                ...period,
+            },
+            recurring: {
+                ...period,
+            },
+        });
+    } catch (exception) {
+        expect(exception.code).toBe(403);
+    }
+});
+
+test('pimAPi Push a new Contract', async () => {
+    // it has to fail with 404 because we don't have any credentials
+    try {
+        const caller = CrystallizeSubscriptionContractManager.update;
+        await caller('62ed5f695978d060e4604c99', {
+            status: {
+                price: 12345567,
+            },
+        });
+    } catch (exception) {
+        expect(exception.code).toBe(403);
+    }
+});


### PR DESCRIPTION
## Context

This PR add a way to easily create a Subscription Contract from a Variant.

There is 2 helpers:
- taking a Variant
- a plan identifier
- a period identifier
- a price variant identifier

Both return a **Template**, also called
```typescript
export type SubscriptionContractInnerDefinition = Omit<
    CreateSubscriptionContractInputRequest,
    'customerIdentifier' | 'payment' | 'addresses' | 'tenantId' | 'status'
>;
```

That you can then reuse to `create` or `update` a contract via
```typescript
CrystallizeSubscriptionContractManager.create({
    ...template,
    customerIdentifier: 'sebastien@crystallize.com',
    payment,
    addresses,
    tenantId,
    status
});
//or
CrystallizeSubscriptionContractManager.update("contractId", {
    ...template,
    payment,
    addresses,
    status
});
```
---

### Use Case 1.: one that fetches all from parameters
```typescript
const template = await CrystallizeSubscriptionContractManager.createSubscriptionContractTemplateBasedOnVariantIdentity(
                '/standard-crystal-customer',
                { id: '62eaf0a5f050cc86e5ded7b1' },
                'crystal-customer',
                '62eaf0535978d060e4604c83',
                'default',
                'en',
            );
```

###  Use Case 2.: data are already in the query (we avoid a useless query

```typescript
const variant: ProductVariant = variantComingFromCodeOrExistingQuery;
const template = await CrystallizeSubscriptionContractManager.createSubscriptionContractTemplateBasedOnVariant(
                variant,
                'crystal-customer',
                '62eaf0535978d060e4604c83',
                'default'
            );
```
