### PR TITLE
fix: Ignore node_modules, dist, and logs from project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
-node_modules
+.DS_Store
+.env
+
+node_modules/
+dist/
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*


### PR DESCRIPTION
This fixes an issue where `dist` and `node_modules` are not ignored when checking out other branches.

Example: `import-export-sdk` currently only exists in a feature branch. Checking out `main` leaves the `dist` and `node_modules` folders in place, as they weren't tracked by git due to the gitignore in the `import-export-sdk`. In `main`, this gitignore does not exist, so the files become tracked by git again. Which is a giant PITA.