### PR TITLE
fix(components/js-api-client): Allow an object of anything as VariablesType

### DIFF
--- a/components/js-api-client/src/core/client.ts
+++ b/components/js-api-client/src/core/client.ts
@@ -7,7 +7,7 @@ export type ClientConfiguration = {
     accessTokenSecret?: string;
 };
 
-export type VariablesType = { [key: string]: string | number | string[] | number[] };
+export type VariablesType = Record<string, any>;
 export type ApiCaller<T> = (query: string, variables?: VariablesType) => Promise<T>;
 
 export type ClientInterface = {


### PR DESCRIPTION
Variables in graphql are not limited to strings, numbers, and arrays of these.

The topic inputs, for example, consist of arrays of objects of arrays of objects to _n_ depth when creating topics with children.

This PR updates the type to be `Record<string, any>`, the equivalent of `{ [x: string]: any }`.