### PR TITLE
feat: [sc-7297] Streamline builds and tests for libraries

### DIFF
--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -2,8 +2,8 @@ name: CI
 
 on:
     push:
-        branches: ["main"]
-    pull_requests:
+        branches: ['main']
+    pull_request:
         types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -47,26 +47,12 @@ jobs:
                   echo ::group::..:: Mono Repo Tests ::..
                   yarn install
                   echo ::endgroup::
-                  for COMPONENT in `ls components`; do
-                      if [ -d "components/${COMPONENT}" ]; then
-                        echo ::group::..:: ${COMPONENT} ::..
-                        cd components/${COMPONENT} && yarn install && cd -;
-                        echo ::endgroup::
-                      fi  
-                  done
 
             - name: 🏄 Run the tests
               run: |
                   echo ::group::..:: Mono Repo Tests ::..
-                  echo "Nothing yet."
+                  yarn test
                   echo ::endgroup::
-                  for COMPONENT in `ls components`; do
-                      if [ -d "components/${COMPONENT}" ]; then
-                        echo ::group::..:: ${COMPONENT} ::..
-                        cd components/${COMPONENT} && yarn build && yarn test && cd -;
-                        echo ::endgroup::
-                      fi  
-                  done
 
     builds:
         name: 👀 Test Standalone Builds

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+    push:
+        branches: ["main"]
+    pull_requests:
+        types: [opened, synchronize]
 
 jobs:
     lint:

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node: [12, 14, 16]
+                node: [14, 16, 18]
         steps:
             - name: 🛑 Cancel Previous Runs
               uses: styfle/cancel-workflow-action@0.9.1
@@ -59,7 +59,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node: [12, 14, 16]
+                node: [14, 16, 18]
         steps:
             - name: 🛑 Cancel Previous Runs
               uses: styfle/cancel-workflow-action@0.9.1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+.turbo

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,8 @@ codeclean: ## Code Clean
 .PHONY: tests
 tests: ## Run the tests
 	@echo " ..:: Mono Repo Testing ::.."
+	@yarn test
 	@yarn prettier --check .
-	@for COMPONENT in $(shell ls components); do \
-    	if [ -d "components/$${COMPONENT}" ]; then \
-    		echo " ..:: Testing $${COMPONENT} ::.."; \
-			cd components/$${COMPONENT} && yarn install && yarn build && yarn test; cd -; \
-		fi \
-	done
 
 .PHONY: bump
 bump: ## Bump all components

--- a/package.json
+++ b/package.json
@@ -10,10 +10,13 @@
     ],
     "devDependencies": {
         "concurrently": "^7.1.0",
-        "prettier": "2.6.0"
+        "prettier": "2.6.0",
+        "turbo": "^1.4.3"
     },
     "scripts": {
-        "watch": "concurrently 'cd components/js-api-client && yarn watch' 'cd components/js-storefrontaware-utils && yarn watch' 'cd components/reactjs-components && yarn watch' 'cd components/reactjs-hooks && yarn watch' 'cd components/node-service-api-request-handlers && yarn watch' 'cd components/node-service-api-router && yarn watch'"
+        "build": "turbo run build",
+        "test": "turbo run test",
+        "dev": "turbo run watch --parallel"
     },
     "volta": {
         "node": "16.14.2",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
     "pipeline": {
         "build": {
             "dependsOn": ["^build"],
-            "outputs": []
+            "outputs": [".dist/**"]
         },
         "test": {
             "dependsOn": ["build"],

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
             "outputs": []
         },
         "test": {
-            "dependsOn": ["^build", "^test"],
+            "dependsOn": ["build"],
             "outputs": []
         },
         "watch": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://turborepo.org/schema.json",
+    "pipeline": {
+        "build": {
+            "dependsOn": ["^build"],
+            "outputs": []
+        },
+        "test": {
+            "dependsOn": ["^build", "^test"],
+            "outputs": []
+        },
+        "watch": {
+            "cache": false
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3150,6 +3150,96 @@ tsscmp@1.0.6:
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
   integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
+turbo-android-arm64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-android-arm64/-/turbo-android-arm64-1.4.3.tgz#d531c6935134d8cae9f31f61db47d13bd227bb93"
+  integrity sha512-ZUvdoEHJkTkOFOO9PKWYrdONDBVqkNsvwEMufTVf07RXgqmbXDPkznzT4hcQm6xXyqWqJdjgSAMdlm+2nNE1Og==
+
+turbo-darwin-64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.4.3.tgz#123e214d9070ec6ac81468dc7a1cb02a459fafd7"
+  integrity sha512-gapoVm5qbu2TJS4lJ6fM3o2eAkLyXSxHihw/4NRAYmwHCH3at1/cIAnRcctB/HLL3ZaB/p3HKb8mnI7k6xNHOw==
+
+turbo-darwin-arm64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.4.3.tgz#9fa062c3ffa9208d0e2fa0155dcb48a290e7c109"
+  integrity sha512-XUe6FTsHamEH7FfNslYYO04yecAaguhZuwW4kE9B/BAP8MUYsmVqONauLPyE/YqM6pf2K0xwVe+RlEGf53CWbg==
+
+turbo-freebsd-64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.4.3.tgz#ffb4a939ca0000ec91114d2bbddc491c4835e862"
+  integrity sha512-1CAjXmDClgMXdWZXreUfAbGBB2WB9TZHfJIdsgnDqt4fIcFGChknzYqc+Fj3tGHAczMpinGjBbWIzFuxOq/ofQ==
+
+turbo-freebsd-arm64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.4.3.tgz#0bab3e2ccfac1ecc9ed9a30b0ab80f379fe3a788"
+  integrity sha512-j5C7j/vwabPKpr5d6YlLgHGHBZCOcXj3HdkBshDHTQ0wghH0NuCUUaesYxI3wva/4/Ec0dhIrb20Laa/HMxXLA==
+
+turbo-linux-32@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.4.3.tgz#96deb5ebedfe6b97fd8ecc0fa40ff1c891c4c04f"
+  integrity sha512-vnc+StXIoQEnxIU43j7rEz/J+v+RV4dbUdUolBq0k9gkUV8KMCcqPkIa753K47E2KLNGKXMaYDI6AHQX1GAQZg==
+
+turbo-linux-64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.4.3.tgz#ed0152e724c78dea090b2d60d29258110bdfb14a"
+  integrity sha512-KAUeIa8Ejt6BLrBGbVurlrjDxqh62tu75D4cqKqKfzWspcbEtmdqlV6qthXfm8SlzGSNuQXX0+qXEWds2FIZXg==
+
+turbo-linux-arm64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.4.3.tgz#74fac47575e6b5af5830d26a56493859d09e4c7c"
+  integrity sha512-rzB7w+RHCQkKr8aDxxozv/IzdN976CYyBiRocSf9QGU73uyAg8pCo3i0MiENSRjDC+tUbdbu2lEUwGXf9ziB9Q==
+
+turbo-linux-arm@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.4.3.tgz#ac42b3c5918fe06270cb8dfbe31442a48cc38fc3"
+  integrity sha512-zZNoHUK5ioFyxAngh8tHe763Dzb22ne3LJkaZn0ExkFHJtWClWv536lPcDuQPpIH9W9iz5OwPKtN32DNpNwk8A==
+
+turbo-linux-mips64le@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.4.3.tgz#d796261795e4fc29935cbffdadfbc11d83cbe616"
+  integrity sha512-Ztr1BM5NiUsHWjB7zpkP2RpRDA/fjbLaCbkyfyGlLmVkrSkh05NFBD03IWs2LSLy/wb6vRpL3MQ4FKcb97Tn8w==
+
+turbo-linux-ppc64le@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.4.3.tgz#b7d043efa27290e074b7aba45bb298fc86bd8cfe"
+  integrity sha512-tJaFJWxwfy/iLd69VHZj6JcXy9hO8LQ+ZUOna/p/wiy5WrFVgEYlD+4gfECfRZ+52EIelMgXl97vACaN1WMhLw==
+
+turbo-windows-32@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.4.3.tgz#3dac4678f1d74ccf0ac187e738d30a557932fbad"
+  integrity sha512-w9LyYd+DW3PYFXu9vQiie5lfdqmVIKLV0h181C49hempkIXfgQAosXfaugYWDwBc0GEBoBIQB0vGQKE7gt5nzA==
+
+turbo-windows-64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.4.3.tgz#b493ab62db70c4c147cf0dc56dc812ea2e15cf3c"
+  integrity sha512-qPCqemxxOrXyqqig3fVQozRkOwo5oJSsQ3FTZE5YlNu2NwwWvY1mC0X4WTZIDsbj4oHqr0riqC7RGKbjQm1IIQ==
+
+turbo-windows-arm64@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.4.3.tgz#be4b38994cb3f1ceb36940ff6d6b227fa2ba53bf"
+  integrity sha512-djnOOBjw33AnUx2SR6TMOpDr3nKLnVD+HcZvnQz70HyE331AKWjBoEE4rtUOteLAfViWAp3afbiljFSOnbU00Q==
+
+turbo@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.4.3.tgz#7221972f47a28bfcb53609e97db9810d2c3a265b"
+  integrity sha512-g08eD2HdO/XW5xGHnXr0cXGiWnrgFBI6pN/3u0EOTeerKAsWIZU0ZrpSnl3whRtImeBB/gQu7Eu1waM2VOxzgw==
+  optionalDependencies:
+    turbo-android-arm64 "1.4.3"
+    turbo-darwin-64 "1.4.3"
+    turbo-darwin-arm64 "1.4.3"
+    turbo-freebsd-64 "1.4.3"
+    turbo-freebsd-arm64 "1.4.3"
+    turbo-linux-32 "1.4.3"
+    turbo-linux-64 "1.4.3"
+    turbo-linux-arm "1.4.3"
+    turbo-linux-arm64 "1.4.3"
+    turbo-linux-mips64le "1.4.3"
+    turbo-linux-ppc64le "1.4.3"
+    turbo-windows-32 "1.4.3"
+    turbo-windows-64 "1.4.3"
+    turbo-windows-arm64 "1.4.3"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"


### PR DESCRIPTION
Story details: https://app.shortcut.com/crystallize/story/7297

In short this does:

1. Add turbo dev dep
2. Configure commands for turbo: `build`, `test`, `dev` (Usage: `yarn build` for example)
3. Change github workflow to run build/test using turbo
4. Remove loop-and-install for components in gh workflow; Not supposed to run install commands for separate components
