### PR TITLE
Add possibility to change customer identifier saved in a token generated by magick link handlers

### DIFF
--- a/components/node-service-api-request-handlers/src/magicklink/types.ts
+++ b/components/node-service-api-request-handlers/src/magicklink/types.ts
@@ -11,7 +11,9 @@ export const magickLinkUserInfosPayload = z
 export type MagickLinkUserInfosPayload = z.infer<typeof magickLinkUserInfosPayload>;
 export type MagickLinkUserInfos = MagickLinkUserInfosPayload;
 
-export type MagickLinkRegisterArguments = {
+type UserIdentifierSelector<T extends MagickLinkUserInfosPayload> = (payload: T) => string;
+
+export type MagickLinkRegisterArguments<T extends MagickLinkUserInfosPayload> = {
     host: string;
     mailer: (subject: string, to: string[] | string, from: string, html: string) => void;
     jwtSecret: string;
@@ -19,12 +21,14 @@ export type MagickLinkRegisterArguments = {
     subject: string;
     from: string;
     buildHtml: (request: MagickLinkUserInfos, link: string) => string;
+    userIdentifierSelector?: UserIdentifierSelector<T>;
 };
 
-export type MagickLinkConfirmArguments = {
+export type MagickLinkConfirmArguments<T extends MagickLinkUserInfosPayload> = {
     jwtSecret: string;
     backLinkPath: string;
     token: string;
     host: string;
     setCookie: (name: string, value: string) => void;
+    userIdentifierSelector?: UserIdentifierSelector<T>;
 };


### PR DESCRIPTION
| Q             | A            |
| ------------- | ------------ |
| Branch?       | main  |
| Bug fix?      | no       |
| New feature?  | yes     |
| BC breaks?    | no       |
| Fixed tickets | n/a       |

This PR is solving an issue that we encountered in our project that occurred when we needed to change the crystallize customer identifier from their email to their phone number. The tokens generated by library magick link handlers stopped working. 
I added a selector that allows to customize which property of the passed in payload becomes the customer identifier saved in the generated token. The default behavior is unchanged, because the identifier selector is optional.
