### PR TITLE
Fix typo in orderItemInputRequest

### DIFF
--- a/components/js-api-client/src/types/order.ts
+++ b/components/js-api-client/src/types/order.ts
@@ -67,7 +67,7 @@ export const orderItemInputRequest = z
         name: z.string(),
         sku: z.string().optional(),
         productId: z.string().optional(),
-        productVairantId: z.string().optional(),
+        productVariantId: z.string().optional(),
         imageUrl: z.string().optional(),
         quantity: z.number(),
         subscription: orderItemSubscriptionInputRequest.optional(),


### PR DESCRIPTION
| Q             | A            |
| ------------- | ------------ |
| Branch?       | main |
| Bug fix?      | yes       |
| New feature?  | no       |
| BC breaks?    |  maybe       |
| Fixed tickets | n/a        |

This PR is fixing a typo that prevented productVariantId from being added to a cart in a new order pushed to Crystallize. 
