### PR TITLE
fix: add type for cart item meta

### DIFF
--- a/components/node-service-api-request-handlers/package.json
+++ b/components/node-service-api-request-handlers/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@crystallize/node-service-api-request-handlers",
     "license": "MIT",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "author": "Crystallize <hello@crystallize.com> (https://crystallize.com)",
     "contributors": [
         "Sébastien Morel <sebastien@crystallize.com>"

--- a/components/node-service-api-request-handlers/src/cart/types.ts
+++ b/components/node-service-api-request-handlers/src/cart/types.ts
@@ -15,6 +15,11 @@ export const cartPayload = z.object({
 export type CartPayload = z.infer<typeof cartPayload>;
 export type CartItemPayload = z.infer<typeof cartItemPayload>;
 
+export interface KeyValuePair {
+    key: string;
+    value?: string;
+}
+
 export interface Cart {
     cart: {
         items: CartItem[];
@@ -29,6 +34,7 @@ export interface CartItem {
     product: Product;
     variant: ProductVariant;
     variantPrice: ProductPriceVariant;
+    meta?: KeyValuePair[];
 }
 
 export interface Price {


### PR DESCRIPTION

| Q             | A            |
| ------------- | ------------ |
| Branch?       | fix/add-type-cart-item-meta-key-value-pair |
| Bug fix?      | yes/no       |
| New feature?  | no       |
| BC breaks?    | no       |
| Fixed tickets | #10085  |

Added type interface for cart item meta key value pair which as meta key did not exist as type before


