### PR TITLE
Fix: Item Rel min max can be 0

### DIFF
--- a/components/schema/package.json
+++ b/components/schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crystallize/schema",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "license": "MIT",
     "type": "module",
     "exports": {
@@ -21,14 +21,14 @@
     },
     "devDependencies": {
         "@tsconfig/node18": "^1.0.1",
-        "@types/node": "^18.0.6",
         "@types/jest": "^28.1.6",
+        "@types/node": "^18.0.6",
+        "jest": "^27.5.1",
         "json": "^11.0.0",
         "mongodb": "^4.9.1",
-        "tsup": "^6.6.3",
-        "jest": "^27.5.1",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.9.1",
+        "tsup": "^6.6.3",
         "typescript": "^4.7.4"
     },
     "peerDependencies": {

--- a/components/schema/src/shape/components.ts
+++ b/components/schema/src/shape/components.ts
@@ -3,7 +3,7 @@ import { IdSchema } from '../shared/index.js';
 import { ShapeComponentTypeEnum } from './enums.js';
 
 const minValueSchema = z.number().min(0).nullable().optional();
-const maxValueSchema = z.number().min(1).nullable().optional();
+const maxValueSchema = z.number().min(0).nullable().optional();
 const minMaxSchema = z.object({ min: minValueSchema, max: maxValueSchema });
 
 export const MinMaxComponentConfigSchema = minMaxSchema
@@ -11,19 +11,23 @@ export const MinMaxComponentConfigSchema = minMaxSchema
         // API throws an error of max being less than min if max is explicitly null.
         // This transform can be removed if the API issue is resolved.
         const result: z.infer<typeof minMaxSchema> = {};
-        if (!!min) {
+        if (min !== null && min !== undefined) {
             result.min = min;
         }
-        if (!!max) {
+        if (max !== null && max !== undefined) {
             result.max = max;
         }
-
         return result;
     })
     .refine(
         ({ min, max }) => {
             if (typeof min === 'number' && typeof max === 'number') {
-                return min <= max;
+                if (min === max) {
+                    return true;
+                }
+                if (min > max) {
+                    return false;
+                }
             }
             return true;
         },

--- a/components/schema/tests/shape/minMaxValidation.test.ts
+++ b/components/schema/tests/shape/minMaxValidation.test.ts
@@ -85,6 +85,15 @@ const testCases: testCase[] = [
         expected: {},
     },
     {
+        name: 'does not error when both min and max are 0',
+        min: 0,
+        max: 0,
+        expected: {
+            min: 0,
+            max: 0,
+        },
+    },
+    {
         name: 'errors when min is negative',
         min: -1,
         error: new ZodError([
@@ -96,21 +105,6 @@ const testCases: testCase[] = [
                 exact: false,
                 message: 'Number must be greater than or equal to 0',
                 path: ['min'],
-            },
-        ]),
-    },
-    {
-        name: 'errors when max is less than 1',
-        max: 0,
-        error: new ZodError([
-            {
-                code: 'too_small',
-                minimum: 1,
-                type: 'number',
-                inclusive: true,
-                exact: false,
-                message: 'Number must be greater than or equal to 1',
-                path: ['max'],
             },
         ]),
     },
@@ -132,6 +126,10 @@ test('minMaxValidation.test', () => {
     testCases.forEach((tc) => {
         const shouldBeSuccess = tc.expected !== undefined;
         const result: any = MinMaxComponentConfigSchema.safeParse({ min: tc.min, max: tc.max });
+
+        if (result.success !== shouldBeSuccess) {
+            console.log(tc, result);
+        }
         expect(result.success).toBe(shouldBeSuccess);
 
         if (shouldBeSuccess) {


### PR DESCRIPTION
Covered the tests in Schema for MinMaxValidation so that min max can be 0 as new use cases are introduced on the app

| Q             | A            |
| ------------- | ------------ |
| Branch?       | main  |
| Bug fix?      | yes       |
| New feature?  | no       |
| BC breaks?    | no       |
| Fixed tickets | #...         |
