### PR TITLE
rm deprecated min max itemrel config queries

### DIFF
--- a/components/import-export-sdk/package.json
+++ b/components/import-export-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crystallize/import-export-sdk",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "license": "MIT",
     "type": "module",
     "exports": {

--- a/components/import-export-sdk/src/shape/queries/fragments/shape.ts
+++ b/components/import-export-sdk/src/shape/queries/fragments/shape.ts
@@ -1,8 +1,6 @@
 export const basicComponentConfigFragment = `
     fragment basicComponentConfig on ComponentConfig {
         ... on ItemRelationsComponentConfig {
-            min
-            max
             minItems
             maxItems
             minSkus

--- a/components/js-api-client/package.json
+++ b/components/js-api-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@crystallize/js-api-client",
     "license": "MIT",
-    "version": "1.12.1",
+    "version": "1.12.2",
     "author": "Crystallize <hello@crystallize.com> (https://crystallize.com)",
     "contributors": [
         "Sébastien Morel <sebastien@crystallize.com>"

--- a/components/js-api-client/src/core/dump-tenant/createSpecQuery.ts
+++ b/components/js-api-client/src/core/dump-tenant/createSpecQuery.ts
@@ -180,8 +180,6 @@ export const getTenantQueries = (tenantId: string) => {
         }
         ... on ItemRelationsComponentConfig {
           acceptedShapeIdentifiers
-          min
-          max
           minSkus
           minItems
           maxSkus


### PR DESCRIPTION
Removed the min max from the Item Relations Config queries in import-export-sdk and in js-api-client

| Q             | A            |
| ------------- | ------------ |
| Branch?       | main|
| Bug fix?      | yes       |
| New feature?  | no       |
| BC breaks?    | no       |
| Fixed tickets | #10412       |
