### PR TITLE
Pass overrides to NodeContent component

### DIFF
--- a/components/reactjs-components/src/content-transformer/component.tsx
+++ b/components/reactjs-components/src/content-transformer/component.tsx
@@ -163,7 +163,7 @@ export const NodeContent = (props: NodeProps) => {
         return (
             <>
                 {props.children.map((child, i) => (
-                    <ContentTransformerNode key={i} {...child} />
+                    <ContentTransformerNode key={i} overrides={props.overrides} {...child} />
                 ))}
             </>
         );


### PR DESCRIPTION
| Q             | A            |
| ------------- | ------------ |
| Branch?  | main |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Fixed tickets | - |

This fix enables overrides to be used on nodes deeper than 1 level.